### PR TITLE
Repository Description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Emma Lightning Talks Contribution Guide
+
+Everyone at Emma is invited to share their knowledge in one or more of our weekly lightning talks.
+If you have a topic that you want to present, just enter it in [Confluence](https://emma-sleep.atlassian.net/wiki/spaces/TECH/pages/2843901953/Lightning+Talks) and sync with the organizer to find a suitable date for your talk.
+
+## Adding Assets to this Repository
+
+To add assets for your lightning talk to this repository, just add a folder with your assets to this repository.
+The folder should follow the following naming scheme `YYYY-MM-DD_name_of_your_lightning_talk` where `YYYY-MM-DD` refers to the date of your lightning talk. Example: `2022-04-12_docker_compose_basics`.
+
+Following this naming scheme ensures that the lightning talk assets appear in order of their presentation date.
+
+After you created your assets, create a pull request and once the pull request is merged, make sure to link the assets as a resource on [Confluence](https://emma-sleep.atlassian.net/wiki/spaces/TECH/pages/2843901953/Lightning+Talks).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# emma-lightning-talks
-Emma Lightning Talks
+# Emma Lightning Talks
+
+This repository contains assets such as sample code for Emma's lightning talks.
+You can find an overview of all lightning talks on [Confluence](https://emma-sleep.atlassian.net/wiki/spaces/TECH/pages/2843901953/Lightning+Talks) and the recordings in our [Emma Lightning Talks channel](https://web.microsoftstream.com/channel/85860719-e99a-4fc6-84be-73524829b0b3).
+
+See [the contribution guide](CONTRIBUTING.md) on how to do a lightning talk and add assets to this repository.


### PR DESCRIPTION
Added repository description (readme and contribution guide) to ensure
that everyone knows where to find our lightning talk overview and recordings
and how to add assets to this repository.
Furthermore, the explanations shall ensure that the directories in this
repository follow a common naming scheme.
